### PR TITLE
Adding install requirement for this package to be v14 rc3 at least

### DIFF
--- a/ExaminePeek/ExaminePeek.csproj
+++ b/ExaminePeek/ExaminePeek.csproj
@@ -30,9 +30,6 @@
 
 	<!-- Nuget references (Depends on stuff that is yet to be on Nuget and is only on MyGet feed) -->
 	<ItemGroup>
-		<PackageReference Include="Umbraco.Cms.Api.Common" Version="14.0.0-rc3" />
-		<PackageReference Include="Umbraco.Cms.Api.Management" Version="14.0.0-rc3" />
-		<PackageReference Include="Umbraco.Cms.Web.Website" Version="14.0.0-rc3" />
 		<PackageReference Include="Umbraco.Cms" Version="14.0.0-rc3" />
 	</ItemGroup>
 

--- a/ExaminePeek/ExaminePeek.csproj
+++ b/ExaminePeek/ExaminePeek.csproj
@@ -33,6 +33,7 @@
 		<PackageReference Include="Umbraco.Cms.Api.Common" Version="14.0.0-rc3" />
 		<PackageReference Include="Umbraco.Cms.Api.Management" Version="14.0.0-rc3" />
 		<PackageReference Include="Umbraco.Cms.Web.Website" Version="14.0.0-rc3" />
+		<PackageReference Include="Umbraco.Cms" Version="14.0.0-rc3" />
 	</ItemGroup>
 
 


### PR DESCRIPTION
ExaminePeek has dependencies that you would think should exclude pre-v14 installs https://github.com/warrenbuckley/Examine-Peek/blob/main/ExaminePeek/ExaminePeek.csproj#L33-L35 

You can see the requirements: https://www.nuget.org/packages/ExaminePeek#dependencies-body-tab

However, since my Umbraco site doesn't have `Umbraco.Cms.Api.Common`, `Umbraco.Cms.Api.Management` nor `Umbraco.Cms.Web.Website` directly installed, the package installs into v13 without complaining. Of course the v13 site stops building after that.

I found that specifying `<PackageReference Include="Umbraco.Cms" Version="14.0.0-rc3" />`  in the csproj file will output in the NuGet file the requirement needed, start at `v14.0.0-rc3` and allow installs in any version higher than that. 

I haven't limited it further @warrenbuckley since I would assume that this package will still work in v15 and 16.. if you want to limit it further, for example exclusively to v14 and anything under v15 then you can use `<PackageReference Include="Umbraco.Cms" Version="[14.0.0-rc3,15.0.0]" /> ` instead. Up to you.

