### PR TITLE
Bugfix for modal not displaying data in 16+

### DIFF
--- a/ExaminePeek/Client/src/Actions/Entity/examinepeek.entityaction.ts
+++ b/ExaminePeek/Client/src/Actions/Entity/examinepeek.entityaction.ts
@@ -32,7 +32,8 @@ export class ExaminePeekEntityAction extends UmbEntityActionBase<never> {
 
         await modal?.onSubmit().catch((_rejected) => {
             // User clicked close/cancel and no data was submitted
-            console.log("rejected", _rejected)
+            // rejected = { type: 'close' }
+            //console.log("rejected", _rejected)
             return;
         });
     }

--- a/ExaminePeek/Client/src/Entrypoints/entrypoint.ts
+++ b/ExaminePeek/Client/src/Entrypoints/entrypoint.ts
@@ -22,6 +22,5 @@ export const onInit: UmbEntryPointOnInit = (host) => {
 };
 
 export const onUnload: UmbEntryPointOnUnload = () => {
-  console.log("Goodbye from Examine Peek👋");
 };
 

--- a/ExaminePeek/Client/src/Modals/examinepeek.modal.element.ts
+++ b/ExaminePeek/Client/src/Modals/examinepeek.modal.element.ts
@@ -1,6 +1,5 @@
 ﻿import { customElement, html, state } from "@umbraco-cms/backoffice/external/lit";
 import { UmbModalBaseElement, UmbModalRejectReason } from "@umbraco-cms/backoffice/modal";
-import { tryExecuteAndNotify } from "@umbraco-cms/backoffice/resources";
 
 import { TemplateResult, css } from "lit";
 
@@ -41,18 +40,18 @@ export class ExaminePeekmModalElement extends UmbModalBaseElement<ExaminePeekMod
     }
     
     private async _getExamineRecord(key: string) : Promise<ISearchResult | undefined> {
-        const { data, error } = await tryExecuteAndNotify(this, ExaminePeekService.getUmbracoExaminepeekApiV1RecordByKey({
+        const { data, error } = await ExaminePeekService.getUmbracoExaminepeekApiV1RecordByKey({
             path: {
                 key: key
             }
-        }));
+        });
         if (error){
             console.error(error);
             return undefined;
         }
         
         this.hasLoadedRecord = true;
-        return data?.data as ISearchResult;
+        return data as ISearchResult;
     }
     
     private async _copyValue(e: Event, textToCopy: string | null) {
@@ -79,7 +78,6 @@ export class ExaminePeekmModalElement extends UmbModalBaseElement<ExaminePeekMod
     };
     
     render() {
-
         const listItems: TemplateResult[] = [];
 
         // Convert the record to an array of entries, sort them by key, then iterate over them


### PR DESCRIPTION
Remove **tryExecuteAndNotify** as deprecated and just using the HeyAPI Fetch Call directly
This was preventing the info from being shown in 16 & 17 in the modal, was fine in 14 & 15